### PR TITLE
make stats export more flexible (fixes #127)

### DIFF
--- a/sparv/modules/misc/misc.py
+++ b/sparv/modules/misc/misc.py
@@ -328,3 +328,33 @@ def source(out: Output = Output("<text>:misc.source"),
            text: Annotation = Annotation("<text>")):
     """Create a document attribute based on the filename of the source file."""
     out.write(name for _ in text.read())
+
+
+@annotator("Get the first annotation from a cwb set")
+def first_from_set(out: Output,
+                   chunk: Annotation,):
+    """"Get the first annotation from a set."""
+    out_annotation = []
+    for val in chunk.read():
+        out_annotation.append(util.misc.set_to_list(val)[0] if util.misc.set_to_list(val) else "")
+    out.write(out_annotation)
+
+
+@annotator("Get the best annotation from a cwb set with scores")
+def best_from_set(out: Output,
+                  chunk: Annotation,
+                  is_sorted: bool = False,
+                  score_sep = ":"):
+    """Get the best annotation from a set with scores.
+
+    If 'is_sorted = True' the input is already sorted. In this case the first value is taken and its score is removed.
+    """
+    out_annotation = []
+    for val in chunk.read():
+        if is_sorted:
+            values = [(v.split(score_sep)[1], v.split(score_sep)[0]) for v in util.misc.set_to_list(val)]
+        else:
+            values = sorted([(v.split(score_sep)[1], v.split(score_sep)[0]) for v in util.misc.set_to_list(val)],
+                             key=lambda x:x[0], reverse=True)
+        out_annotation.append(values[0][1] if values else "")
+    out.write(out_annotation)

--- a/sparv/modules/stats_export/__init__.py
+++ b/sparv/modules/stats_export/__init__.py
@@ -2,13 +2,19 @@
 
 from sparv.api import Config
 
-from . import stats_export
+from . import stats_export, sbx_stats
 
 __config__ = [
-    Config("stats_export.include_all_compounds", default=False,
-           description="Whether to include compound analyses for every word or just for the words that are lacking "
-                       "a sense annotation"),
+    Config("stats_export.annotations", description="Sparv annotations to include."),
+    Config("stats_export.source_annotations",
+           description="List of annotations and attributes from the source data to include. Everything will be "
+                       "included by default."),
+    Config("stats_export.column_names", default=[],
+           description="Optional custom column names that will be printed in the header. First element is the token, "
+                       "followed by all token attributes, followed by all structural attributes."),
     Config("stats_export.delimiter", default="\t", description="Delimiter separating columns"),
     Config("stats_export.cutoff", default=1,
-           description="The minimum frequency a word must have in order to be included in the result")
+           description="The minimum frequency a word must have in order to be included in the result"),
+    Config("stats_export.remote_host", "", description="Remote host to install to"),
+    Config("stats_export.remote_dir", "", description="Path on remote host to install to")
 ]

--- a/sparv/modules/stats_export/__init__.py
+++ b/sparv/modules/stats_export/__init__.py
@@ -7,11 +7,8 @@ from . import stats_export, sbx_stats
 __config__ = [
     Config("stats_export.annotations", description="Sparv annotations to include."),
     Config("stats_export.source_annotations",
-           description="List of annotations and attributes from the source data to include. Everything will be "
-                       "included by default."),
-    Config("stats_export.column_names", default=[],
-           description="Optional custom column names that will be printed in the header. First element is the token, "
-                       "followed by all token attributes, followed by all structural attributes."),
+           description="List of annotations and attributes from the source data to include. None will be included by "
+                       "default."),
     Config("stats_export.delimiter", default="\t", description="Delimiter separating columns"),
     Config("stats_export.cutoff", default=1,
            description="The minimum frequency a word must have in order to be included in the result"),

--- a/sparv/modules/stats_export/sbx_stats.py
+++ b/sparv/modules/stats_export/sbx_stats.py
@@ -100,7 +100,24 @@ def sbx_freq_list(
               out=out, sparv_namespace="", source_namespace="", delimiter=delimiter, cutoff=cutoff)
 
 
-@exporter("Corpus word frequency list (without Swedish annotations)", order=2)
+@exporter("Corpus word frequency list (without Swedish annotations)", language=["swe"], order=2)
+def sbx_freq_list_simple_swe(
+    source_files: AllSourceFilenames = AllSourceFilenames(),
+    token: AnnotationAllSourceFiles = AnnotationAllSourceFiles("<token>"),
+    word: AnnotationAllSourceFiles = AnnotationAllSourceFiles("<token:word>"),
+    pos: AnnotationAllSourceFiles = AnnotationAllSourceFiles("<token:pos>"),
+    baseform: AnnotationAllSourceFiles = AnnotationAllSourceFiles("<token>:stats_export.baseform_first"),
+    out: Export = Export("frequency_list_sbx/stats_[metadata.id].csv"),
+    delimiter: str = Config("stats_export.delimiter"),
+    cutoff: int = Config("stats_export.cutoff")):
+    """Create a word frequency list for a corpus without sense, lemgram and complemgram annotations."""
+    annotations = [(word, "token"), (pos, "POS"), (baseform, "lemma")]
+
+    freq_list(source_files=source_files, word=word, token=token, annotations=annotations, source_annotations=[],
+              out=out, sparv_namespace="", source_namespace="", delimiter=delimiter, cutoff=cutoff)
+
+
+@exporter("Corpus word frequency list (without Swedish annotations)", order=3)
 def sbx_freq_list_simple(
     source_files: AllSourceFilenames = AllSourceFilenames(),
     token: AnnotationAllSourceFiles = AnnotationAllSourceFiles("<token>"),
@@ -117,7 +134,7 @@ def sbx_freq_list_simple(
               out=out, sparv_namespace="", source_namespace="", delimiter=delimiter, cutoff=cutoff)
 
 
-@exporter("Corpus word frequency list for Old Swedish (without part-of-speech)", language=["swe-fsv"], order=3)
+@exporter("Corpus word frequency list for Old Swedish (without part-of-speech)", language=["swe-fsv"], order=4)
 def sbx_freq_list_fsv(
     source_files: AllSourceFilenames = AllSourceFilenames(),
     token: AnnotationAllSourceFiles = AnnotationAllSourceFiles("<token>"),

--- a/sparv/modules/stats_export/sbx_stats.py
+++ b/sparv/modules/stats_export/sbx_stats.py
@@ -1,0 +1,151 @@
+"""SBX specific annotation and export functions related to the stats export."""
+
+from sparv.api import (AllSourceFilenames, Annotation, AnnotationAllSourceFiles, Config, Export, ExportInput, Output,
+                       OutputCommonData, annotator, exporter, get_logger, installer, util)
+
+from .stats_export import freq_list
+
+logger = get_logger(__name__)
+
+
+@annotator("Extract the complemgram with the highest score", language=["swe"])
+def best_complemgram(
+        out: Output = Output("<token>:stats_export.complemgram_best", description="Complemgram annotation with highest score"),
+        complemgram: Annotation = Annotation("<token>:saldo.complemgram")):
+    """Extract the complemgram with the highest score."""
+    from sparv.modules.misc import misc
+    misc.best_from_set(out, complemgram, is_sorted=True)
+
+
+@annotator("Extract the sense with the highest score", language=["swe"])
+def best_sense(
+        out: Output = Output("<token>:stats_export.sense_best", description="Sense annotation with highest score"),
+        sense: Annotation = Annotation("<token>:wsd.sense")):
+    """Extract the sense annotation with the highest score."""
+    from sparv.modules.misc import misc
+    misc.best_from_set(out, sense, is_sorted=True)
+
+
+@annotator("Extract the first baseform annotation from a set of baseforms", language=["swe"])
+def first_baseform(
+        out: Output = Output("<token>:stats_export.baseform_first", description="First baseform from a set of baseforms"),
+        baseform: Annotation = Annotation("<token:baseform>")):
+    """Extract the first baseform annotation from a set of baseforms."""
+    from sparv.modules.misc import misc
+    misc.first_from_set(out, baseform)
+
+
+@annotator("Extract the first lemgram annotation from a set of lemgrams", language=["swe"])
+def first_lemgram(
+        out: Output = Output("<token>:stats_export.lemgram_first", description="First lemgram from a set of lemgrams"),
+        lemgram: Annotation = Annotation("<token>:saldo.lemgram")):
+    """Extract the first lemgram annotation from a set of lemgrams."""
+    from sparv.modules.misc import misc
+    misc.first_from_set(out, lemgram)
+
+
+@annotator("Get the best complemgram if the token is lacking a sense annotation", language=["swe"])
+def conditional_best_complemgram(
+    out_complemgrams: Output = Output("<token>:stats_export.complemgram_best_cond",
+                                      description="Compound analysis using lemgrams"),
+    complemgrams: Annotation= Annotation("<token>:stats_export.complemgram_best"),
+    sense: Annotation = Annotation("<token:sense>")):
+    """Get the best complemgram if the token is lacking a sense annotation."""
+    all_annotations = list(complemgrams.read_attributes((complemgrams, sense)))
+    short_complemgrams = []
+    for complemgram, sense in all_annotations:
+        if sense and sense != "|":
+            complemgram = ""
+        short_complemgrams.append(complemgram)
+    out_complemgrams.write(short_complemgrams)
+
+
+@exporter("Corpus word frequency list", language=["swe"], order=1)
+def sbx_freq_list(
+    source_files: AllSourceFilenames = AllSourceFilenames(),
+    word: AnnotationAllSourceFiles = AnnotationAllSourceFiles("<token:word>"),
+    token: AnnotationAllSourceFiles = AnnotationAllSourceFiles("<token>"),
+    msd: AnnotationAllSourceFiles = AnnotationAllSourceFiles("<token:msd>"),
+    baseform: AnnotationAllSourceFiles = AnnotationAllSourceFiles("<token>:stats_export.baseform_first"),
+    sense: AnnotationAllSourceFiles = AnnotationAllSourceFiles("<token>:stats_export.sense_best"),
+    lemgram: AnnotationAllSourceFiles = AnnotationAllSourceFiles("<token>:stats_export.lemgram_first"),
+    complemgram: AnnotationAllSourceFiles = AnnotationAllSourceFiles(
+                                            "<token>:stats_export.complemgram_best_cond"),
+    out: Export = Export("frequency_list_sbx/stats_[metadata.id].csv"),
+    delimiter: str = Config("stats_export.delimiter"),
+    cutoff: int = Config("stats_export.cutoff")):
+    """Create a word frequency list for the entire corpus.
+
+    Args:
+        source_files (list, optional): The source files belonging to this corpus. Defaults to AllSourceFilenames.
+        word (str, optional): Word annotations. Defaults to AnnotationAllSourceFiles("<token:word>").
+        token (str, optional): Token span annotations. Defaults to AnnotationAllSourceFiles("<token>").
+        msd (str, optional): MSD annotations. Defaults to AnnotationAllSourceFiles("<token:msd>").
+        baseform (str, optional): Annotations with first baseform from each set.
+            Defaults to AnnotationAllSourceFiles("<token:baseform>").
+        sense (str, optional): Best sense annotations. Defaults to AnnotationAllSourceFiles("<token:sense>").
+        lemgram (str, optional): Annotations with first lemgram from each set.
+            Defaults to AnnotationAllSourceFiles("<token>:saldo.lemgram").
+        complemgram (str, optional): Conditional best compound lemgram annotations.
+            Defaults to AnnotationAllSourceFiles("<token>:saldo.complemgram").
+        out (str, optional): The output word frequency file. Defaults to Export("frequency_list_sbx/[metadata.id].csv").
+        delimiter (str, optional): Column delimiter to use in the csv. Defaults to Config("stats_export.delimiter").
+        cutoff (int, optional): The minimum frequency a word must have in order to be included in the result.
+            Defaults to Config("stats_export.cutoff").
+    """
+    annotations=[(a, None) for a in [word, msd, baseform, sense, lemgram, complemgram]]
+    column_names = ["token", "POS", "lemma", "SALDO sense", "lemgram", "compound"]
+
+    freq_list(source_files=source_files, word=word, token=token,
+              annotations=annotations, source_annotations=[], column_names=column_names, out=out, sparv_namespace="",
+              source_namespace="", delimiter=delimiter, cutoff=cutoff)
+
+
+@exporter("Corpus word frequency list (without Swedish annotations)", order=2)
+def sbx_freq_list_simple(
+    source_files: AllSourceFilenames = AllSourceFilenames(),
+    token: AnnotationAllSourceFiles = AnnotationAllSourceFiles("<token>"),
+    word: AnnotationAllSourceFiles = AnnotationAllSourceFiles("<token:word>"),
+    pos: AnnotationAllSourceFiles = AnnotationAllSourceFiles("<token:pos>"),
+    baseform: AnnotationAllSourceFiles = AnnotationAllSourceFiles("<token:baseform>"),
+    out: Export = Export("frequency_list_sbx/stats_[metadata.id].csv"),
+    delimiter: str = Config("stats_export.delimiter"),
+    cutoff: int = Config("stats_export.cutoff")):
+    """Create a word frequency list for a corpus without sense, lemgram and complemgram annotations."""
+
+    annotations=[(a, None) for a in [word, pos, baseform]]
+    column_names = ["token", "POS", "lemma"]
+
+    freq_list(source_files=source_files, word=word, token=token,
+              annotations=annotations, source_annotations=[], column_names=column_names, out=out, sparv_namespace="",
+              source_namespace="", delimiter=delimiter, cutoff=cutoff)
+
+
+@exporter("Corpus word frequency list for Old Swedish (without part-of-speech)", language=["swe-fsv"], order=3)
+def sbx_freq_list_fsv(
+    source_files: AllSourceFilenames = AllSourceFilenames(),
+    token: AnnotationAllSourceFiles = AnnotationAllSourceFiles("<token>"),
+    word: AnnotationAllSourceFiles = AnnotationAllSourceFiles("<token:word>"),
+    baseform: AnnotationAllSourceFiles = AnnotationAllSourceFiles("<token:baseform>"),
+    lemgram: AnnotationAllSourceFiles = AnnotationAllSourceFiles("<token:lemgram>"),
+    out: Export = Export("frequency_list_sbx/stats_[metadata.id].csv"),
+    delimiter: str = Config("stats_export.delimiter"),
+    cutoff: int = Config("stats_export.cutoff")):
+    """Create a word frequency list for a corpus without sense, lemgram and complemgram annotations."""
+    annotations=[(a, None) for a in [word, baseform, lemgram]]
+    column_names = ["token", "POS", "lemgram"]
+
+    freq_list(source_files=source_files, word=word, token=token,
+              annotations=annotations, source_annotations=[], column_names=column_names, out=out, sparv_namespace="",
+              source_namespace="", delimiter=delimiter, cutoff=cutoff)
+
+
+@installer("Install SBX word frequency list on remote host")
+def install_sbx_freq_list(
+    freq_list: ExportInput = ExportInput("frequency_list_sbx/stats_[metadata.id].csv"),
+    out: OutputCommonData = OutputCommonData("stats_export.install_freq_list_marker"),
+    host: str = Config("stats_export.remote_host"),
+    target_dir: str = Config("stats_export.remote_dir")):
+    """Install frequency list on server by rsyncing."""
+    util.install.install_file(freq_list, host, target_dir)
+    out.write("")

--- a/sparv/modules/stats_export/sbx_stats.py
+++ b/sparv/modules/stats_export/sbx_stats.py
@@ -143,7 +143,7 @@ def sbx_freq_list_fsv(
 @installer("Install SBX word frequency list on remote host")
 def install_sbx_freq_list(
     freq_list: ExportInput = ExportInput("frequency_list_sbx/stats_[metadata.id].csv"),
-    out: OutputCommonData = OutputCommonData("stats_export.install_freq_list_marker"),
+    out: OutputCommonData = OutputCommonData("stats_export.install_sbx_freq_list_marker"),
     host: str = Config("stats_export.remote_host"),
     target_dir: str = Config("stats_export.remote_dir")):
     """Install frequency list on server by rsyncing."""

--- a/sparv/modules/stats_export/sbx_stats.py
+++ b/sparv/modules/stats_export/sbx_stats.py
@@ -93,12 +93,11 @@ def sbx_freq_list(
         cutoff (int, optional): The minimum frequency a word must have in order to be included in the result.
             Defaults to Config("stats_export.cutoff").
     """
-    annotations=[(a, None) for a in [word, msd, baseform, sense, lemgram, complemgram]]
-    column_names = ["token", "POS", "lemma", "SALDO sense", "lemgram", "compound"]
+    annotations = [(word, "token"), (msd, "POS"), (baseform, "lemma"), (sense, "SALDO sense"), (lemgram, "lemgram"),
+                   (complemgram, "compound")]
 
-    freq_list(source_files=source_files, word=word, token=token,
-              annotations=annotations, source_annotations=[], column_names=column_names, out=out, sparv_namespace="",
-              source_namespace="", delimiter=delimiter, cutoff=cutoff)
+    freq_list(source_files=source_files, word=word, token=token, annotations=annotations, source_annotations=[],
+              out=out, sparv_namespace="", source_namespace="", delimiter=delimiter, cutoff=cutoff)
 
 
 @exporter("Corpus word frequency list (without Swedish annotations)", order=2)
@@ -112,13 +111,10 @@ def sbx_freq_list_simple(
     delimiter: str = Config("stats_export.delimiter"),
     cutoff: int = Config("stats_export.cutoff")):
     """Create a word frequency list for a corpus without sense, lemgram and complemgram annotations."""
+    annotations = [(word, "token"), (pos, "POS"), (baseform, "lemma")]
 
-    annotations=[(a, None) for a in [word, pos, baseform]]
-    column_names = ["token", "POS", "lemma"]
-
-    freq_list(source_files=source_files, word=word, token=token,
-              annotations=annotations, source_annotations=[], column_names=column_names, out=out, sparv_namespace="",
-              source_namespace="", delimiter=delimiter, cutoff=cutoff)
+    freq_list(source_files=source_files, word=word, token=token, annotations=annotations, source_annotations=[],
+              out=out, sparv_namespace="", source_namespace="", delimiter=delimiter, cutoff=cutoff)
 
 
 @exporter("Corpus word frequency list for Old Swedish (without part-of-speech)", language=["swe-fsv"], order=3)
@@ -132,12 +128,10 @@ def sbx_freq_list_fsv(
     delimiter: str = Config("stats_export.delimiter"),
     cutoff: int = Config("stats_export.cutoff")):
     """Create a word frequency list for a corpus without sense, lemgram and complemgram annotations."""
-    annotations=[(a, None) for a in [word, baseform, lemgram]]
-    column_names = ["token", "POS", "lemgram"]
+    annotations = [(word, "token"), (baseform, "lemma"), (lemgram, "lemgram")]
 
-    freq_list(source_files=source_files, word=word, token=token,
-              annotations=annotations, source_annotations=[], column_names=column_names, out=out, sparv_namespace="",
-              source_namespace="", delimiter=delimiter, cutoff=cutoff)
+    freq_list(source_files=source_files, word=word, token=token, annotations=annotations, source_annotations=[],
+              out=out, sparv_namespace="", source_namespace="", delimiter=delimiter, cutoff=cutoff)
 
 
 @installer("Install SBX word frequency list on remote host")

--- a/sparv/modules/stats_export/stats_export.py
+++ b/sparv/modules/stats_export/stats_export.py
@@ -62,8 +62,12 @@ def freq_list(source_files: AllSourceFilenames = AllSourceFilenames(),
         for struct_annotation in struct_annotations:
             struct_annot = Annotation(struct_annotation.name, source_file=source_file)
             token_parents = Annotation(token.name, source_file=source_file).get_parents(struct_annot)
-            struct_annot_list = list(struct_annot.read())
-            struct_values.append([struct_annot_list[p] if p is not None else "" for p in token_parents])
+            try:
+                struct_annot_list = list(struct_annot.read())
+                struct_values.append([struct_annot_list[p] if p is not None else "" for p in token_parents])
+            # Handle cases where some source files are missing structural source annotations
+            except FileNotFoundError:
+                struct_values.append(["" for _ in token_parents])
 
         # Create tuples with annotations for each token and count frequencies
         tokens = word.read_attributes(source_file, token_annotations)

--- a/sparv/modules/stats_export/stats_export.py
+++ b/sparv/modules/stats_export/stats_export.py
@@ -32,8 +32,8 @@ def freq_list(source_files: AllSourceFilenames = AllSourceFilenames(),
         token (str, optional): Token span annotations. Defaults to AnnotationAllSourceFiles("<token>").
         annotations (str, optional): All automatic annotations to include in the export. Defaults to
             ExportAnnotationsAllSourceFiles("stats_export.annotations").
-        source_annotations (str, optional): All source annotations to include in the export. Defaults to
-            SourceAnnotations("stats_export.source_annotations").
+        source_annotations (str, optional): All source annotations to include in the export. If left empty, none will be
+            included. Defaults to SourceAnnotations("stats_export.source_annotations").
         column_names (list, optional): Optional custom column names that will be printed in the header. First element is
             the token, followed by all token attributes, followed by all structural attributes.
             Defaults to Config("stats_export.column_names").
@@ -51,7 +51,7 @@ def freq_list(source_files: AllSourceFilenames = AllSourceFilenames(),
 
     # Get annotations list and export names
     annotation_list, token_attributes, export_names = util.export.get_annotation_names(
-        annotations, source_annotations, source_files=source_files, token_name=token.name,
+        annotations, source_annotations or [], source_files=source_files, token_name=token.name,
         remove_namespaces=remove_namespaces, sparv_namespace=sparv_namespace, source_namespace=source_namespace)
 
     # Get all token and struct annotations (except the span annotations)

--- a/sparv/modules/stats_export/stats_export.py
+++ b/sparv/modules/stats_export/stats_export.py
@@ -4,8 +4,8 @@ import csv
 from collections import defaultdict
 
 from sparv.api import (AllSourceFilenames, Annotation, AnnotationAllSourceFiles, Config, Export,
-                       ExportAnnotationsAllSourceFiles, ExportInput, OutputCommonData, SourceAnnotations,
-                       SparvErrorMessage, exporter, get_logger, installer, util)
+                       ExportAnnotationsAllSourceFiles, ExportInput, OutputCommonData, SourceAnnotations, exporter,
+                       get_logger, installer, util)
 
 logger = get_logger(__name__)
 

--- a/sparv/modules/stats_export/stats_export.py
+++ b/sparv/modules/stats_export/stats_export.py
@@ -1,131 +1,98 @@
-"""Build word frequency list."""
+"""Build word frequency list (SBX format)."""
 
 import csv
 from collections import defaultdict
 
-from sparv.api import (AllSourceFilenames, AnnotationAllSourceFiles, Config, Export, ExportInput, OutputCommonData, exporter,
-                       get_logger, installer, util)
+from sparv.api import (AllSourceFilenames, Annotation, AnnotationAllSourceFiles, Config, Export,
+                       ExportAnnotationsAllSourceFiles, ExportInput, OutputCommonData, SourceAnnotations,
+                       SparvErrorMessage, exporter, get_logger, installer, util)
 
 logger = get_logger(__name__)
 
 
-@exporter("Corpus word frequency list", language=["swe"], order=1)
+@exporter("Corpus word frequency list")
 def freq_list(source_files: AllSourceFilenames = AllSourceFilenames(),
-              word: AnnotationAllSourceFiles = AnnotationAllSourceFiles("<token:word>"),
-              msd: AnnotationAllSourceFiles = AnnotationAllSourceFiles("<token:msd>"),
-              baseform: AnnotationAllSourceFiles = AnnotationAllSourceFiles("<token:baseform>"),
-              sense: AnnotationAllSourceFiles = AnnotationAllSourceFiles("<token:sense>"),
-              lemgram: AnnotationAllSourceFiles = AnnotationAllSourceFiles("<token>:saldo.lemgram"),
-              complemgram: AnnotationAllSourceFiles = AnnotationAllSourceFiles("<token>:saldo.complemgram"),
+              word: AnnotationAllSourceFiles = AnnotationAllSourceFiles("[export.word]"),
+              token: AnnotationAllSourceFiles = AnnotationAllSourceFiles("<token>"),
+              annotations: ExportAnnotationsAllSourceFiles =
+                  ExportAnnotationsAllSourceFiles("stats_export.annotations"),
+              source_annotations: SourceAnnotations = SourceAnnotations("stats_export.source_annotations"),
+              column_names: list = Config("stats_export.column_names"),
+              remove_namespaces: bool = Config("export.remove_module_namespaces", True),
+              sparv_namespace: str = Config("export.sparv_namespace"),
+              source_namespace: str = Config("export.source_namespace"),
               out: Export = Export("frequency_list/stats_[metadata.id].csv"),
               delimiter: str = Config("stats_export.delimiter"),
-              cutoff: int = Config("stats_export.cutoff"),
-              include_all_compounds: bool = Config("stats_export.include_all_compounds")):
+              cutoff: int = Config("stats_export.cutoff")):
     """Create a word frequency list for the entire corpus.
 
     Args:
         source_files (list, optional): The source files belonging to this corpus. Defaults to AllSourceFilenames.
         word (str, optional): Word annotations. Defaults to AnnotationAllSourceFiles("<token:word>").
-        msd (str, optional): MSD annotations. Defaults to AnnotationAllSourceFiles("<token:msd>").
-        baseform (str, optional): Baseform annotations. Defaults to AnnotationAllSourceFiles("<token:baseform>").
-        sense (str, optional): Sense annotations. Defaults to AnnotationAllSourceFiles("<token:sense>").
-        lemgram (str, optional): Lemgram annotations. Defaults to AnnotationAllSourceFiles("<token>:saldo.lemgram").
-        complemgram (str, optional): Compound lemgram annotations.
-            Defaults to AnnotationAllSourceFiles("<token>:saldo.complemgram").
+        token (str, optional): Token span annotations. Defaults to AnnotationAllSourceFiles("<token>").
+        annotations (str, optional): All automatic annotations to include in the export. Defaults to
+            ExportAnnotationsAllSourceFiles("stats_export.annotations").
+        source_annotations (str, optional): All source annotations to include in the export. Defaults to
+            SourceAnnotations("stats_export.source_annotations").
+        column_names (list, optional): Optional custom column names that will be printed in the header. First element is
+            the token, followed by all token attributes, followed by all structural attributes.
+            Defaults to Config("stats_export.column_names").
+        remove_namespaces: Whether to remove module "namespaces" from element and attribute names.
+            Disabled by default.
+        sparv_namespace: The namespace to be added to all Sparv annotations.
+        source_namespace: The namespace to be added to all annotations present in the source.
         out (str, optional): The output word frequency file. Defaults to Export("frequency_list/[metadata.id].csv").
         delimiter (str, optional): Column delimiter to use in the csv. Defaults to Config("stats_export.delimiter").
         cutoff (int, optional): The minimum frequency a word must have in order to be included in the result.
             Defaults to Config("stats_export.cutoff").
-        include_all_compounds (bool, optional): Whether to include compound analyses for every word
-            or just for the words that are lacking a sense annotation.
-            Defaults to Config("stats_export.include_all_compounds").
     """
+    # Add "word" to annotations
+    annotations = [(word, None)] + annotations
+
+    # Get annotations list and export names
+    annotation_list, token_attributes, export_names = util.export.get_annotation_names(
+        annotations, source_annotations, source_files=source_files, token_name=token.name,
+        remove_namespaces=remove_namespaces, sparv_namespace=sparv_namespace, source_namespace=source_namespace)
+
+    # Get all token and struct annotations (except the span annotations)
+    token_annotations = [a for a in annotation_list if a.attribute_name in token_attributes]
+    struct_annotations = [a for a in annotation_list if ":" in a.name and a.attribute_name not in token_attributes]
+
+    # Create header
+    struct_header_names = [export_names[a.annotation_name] + ":" + export_names[a.name] for a in struct_annotations]
+    auto_column_names = [export_names[a.name] for a in token_annotations] + struct_header_names
+    if column_names:
+        # Check if list of supplied column names has the correct length
+        if len(column_names) != len(auto_column_names):
+            raise SparvErrorMessage(
+                f"The amount of column_names provided ({len(column_names)}) does not match the amount of annotations "
+                f"in the stats export ({len(token_annotations) + len(struct_annotations)}). "
+                f"The following annotations will be included: {', '.join(auto_column_names)}")
+    else:
+        column_names = auto_column_names
+    column_names.append("count")
+
+    # Calculate token frequencies
     freq_dict = defaultdict(int)
-
     for source_file in source_files:
-        tokens = word.read_attributes(source_file, [word, msd, baseform, sense, lemgram, complemgram])
-        update_freqs(tokens, freq_dict, include_all_compounds)
+        # Get values for struct annotations (per token)
+        struct_values = []
+        for struct_annotation in struct_annotations:
+            struct_annot = Annotation(struct_annotation.name, source_file=source_file)
+            token_parents = Annotation(token.name, source_file=source_file).get_parents(struct_annot)
+            struct_annot_list = list(struct_annot.read())
+            struct_values.append([struct_annot_list[p] if p is not None else "" for p in token_parents])
 
-    write_csv(out, freq_dict, delimiter, cutoff)
+        # Create tuples with annotations for each token and count frequencies
+        tokens = word.read_attributes(source_file, token_annotations)
+        for n, token_annotations_tuple in enumerate(tokens):
+            structs_tuple = tuple([struct[n] for struct in struct_values])
+            freq_dict[token_annotations_tuple + structs_tuple] += 1
 
-
-@exporter("Corpus word frequency list (without Swedish annotations)", order=2)
-def freq_list_simple(source_files: AllSourceFilenames = AllSourceFilenames(),
-                     word: AnnotationAllSourceFiles = AnnotationAllSourceFiles("<token:word>"),
-                     pos: AnnotationAllSourceFiles = AnnotationAllSourceFiles("<token:pos>"),
-                     baseform: AnnotationAllSourceFiles = AnnotationAllSourceFiles("<token:baseform>"),
-                     out: Export = Export("frequency_list/stats_[metadata.id].csv"),
-                     delimiter: str = Config("stats_export.delimiter"),
-                     cutoff: int = Config("stats_export.cutoff")):
-    """Create a word frequency list for a corpus without sense, lemgram and complemgram annotations."""
-    freq_dict = defaultdict(int)
-
-    for source_file in source_files:
-        simple_tokens = word.read_attributes(source_file, [word, pos, baseform])
-
-        # Add empty annotations for sense, lemgram and complemgram
-        tokens = []
-        for w, p, b in simple_tokens:
-            tokens.append((w, p, b, "|", "|", "|"))
-        update_freqs(tokens, freq_dict)
-
-    write_csv(out, freq_dict, delimiter, cutoff)
+    write_csv(out, column_names, freq_dict, delimiter, cutoff)
 
 
-@exporter("Corpus word frequency list for Old Swedish (without part-of-speech)", language=["swe-fsv"], order=3)
-def freq_list_fsv(source_files: AllSourceFilenames = AllSourceFilenames(),
-                  word: AnnotationAllSourceFiles = AnnotationAllSourceFiles("<token:word>"),
-                  baseform: AnnotationAllSourceFiles = AnnotationAllSourceFiles("<token:baseform>"),
-                  lemgram: AnnotationAllSourceFiles = AnnotationAllSourceFiles("<token:lemgram>"),
-                  out: Export = Export("frequency_list/stats_[metadata.id].csv"),
-                  delimiter: str = Config("stats_export.delimiter"),
-                  cutoff: int = Config("stats_export.cutoff")):
-    """Create a word frequency list for a corpus without sense, lemgram and complemgram annotations."""
-    freq_dict = defaultdict(int)
-
-    for source_file in source_files:
-        simple_tokens = word.read_attributes(source_file, [word, baseform, lemgram])
-
-        # Add empty annotations for sense, lemgram and complemgram
-        tokens = []
-        for w, b, lem in simple_tokens:
-            tokens.append((w, "", b, "|", lem, "|"))
-        update_freqs(tokens, freq_dict, include_all_lemgrams=True, include_all_baseforms=True)
-
-    write_csv(out, freq_dict, delimiter, cutoff)
-
-
-def update_freqs(tokens, freq_dict, include_all_compounds=False, include_all_lemgrams=False, include_all_baseforms=False):
-    """Extract annotation info and update frequencies."""
-    for word, msd, baseform, sense, lemgram, complemgram in tokens:
-        if "|" in baseform and not include_all_baseforms:
-            baseform = baseform.split("|")[1]
-        sense = sense.split("|")[1].split(":")[0]
-        if not include_all_lemgrams:
-            lemgram = lemgram.split("|")[1].split(":")[0]
-        complemgram = complemgram.split("|")[1].split(":")[0]
-        if not include_all_compounds:
-            if sense:
-                complemgram = ""
-        freq_dict[(word, msd, baseform, sense, lemgram, complemgram)] += 1
-
-
-def write_csv(out, freq_dict, delimiter, cutoff):
-    """Write csv file."""
-    with open(out, "w") as csvfile:
-        csv_writer = csv.writer(csvfile, delimiter=delimiter)
-        csv_writer.writerow(["token", "POS", "lemma", "SALDO sense", "lemgram", "compound", "count"])
-        for (wordform, msd, lemma, sense, lemgram, complemgram), freq in sorted(freq_dict.items(), key=lambda x: -x[1]):
-            if cutoff and cutoff > freq:
-                break
-            csv_writer.writerow([wordform, msd, lemma, sense, lemgram, complemgram, freq])
-    logger.info("Exported: %s", out)
-
-
-@installer("Install word frequency list on remote host", config=[
-    Config("stats_export.remote_host", "", description="Remote host to install to"),
-    Config("stats_export.remote_dir", "", description="Path on remote host to install to")
-])
+@installer("Install word frequency list on remote host")
 def install_freq_list(freq_list: ExportInput = ExportInput("frequency_list/stats_[metadata.id].csv"),
                       out: OutputCommonData = OutputCommonData("stats_export.install_freq_list_marker"),
                       host: str = Config("stats_export.remote_host"),
@@ -133,3 +100,19 @@ def install_freq_list(freq_list: ExportInput = ExportInput("frequency_list/stats
     """Install frequency list on server by rsyncing."""
     util.install.install_file(freq_list, host, target_dir)
     out.write("")
+
+
+################################################################################
+# Auxiliaries
+################################################################################
+
+def write_csv(out, column_names, freq_dict, delimiter, cutoff):
+    """Write csv file."""
+    with open(out, "w") as csvfile:
+        csv_writer = csv.writer(csvfile, delimiter=delimiter)
+        csv_writer.writerow(column_names)
+        for annotations, freq in sorted(freq_dict.items(), key=lambda x: -x[1]):
+            if cutoff and cutoff > freq:
+                break
+            csv_writer.writerow(list(annotations) + [freq])
+    logger.info("Exported: %s", out)

--- a/tests/test_corpora/freeling-eng-slevel/config.yaml
+++ b/tests/test_corpora/freeling-eng-slevel/config.yaml
@@ -63,7 +63,7 @@ export:
         - cwb:vrt
         - cwb:vrt_scrambled
         - korp:timespan_sql
-        - stats_export:freq_list_simple
+        - stats_export:sbx_freq_list_simple
         - xml_export:pretty
         - xml_export:preserved_format
     # Automatic annotations to be included in the export

--- a/tests/test_corpora/freeling-eng-slevel/gold_export/frequency_list/stats_freeling-eng-slevel.csv
+++ b/tests/test_corpora/freeling-eng-slevel/gold_export/frequency_list/stats_freeling-eng-slevel.csv
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7f154c814667d43d8de67f336a6a1c036fb5e245ab322d24581899b23c06cfba
-size 1517

--- a/tests/test_corpora/freeling-eng-slevel/gold_export/frequency_list_sbx/stats_freeling-eng-slevel.csv
+++ b/tests/test_corpora/freeling-eng-slevel/gold_export/frequency_list_sbx/stats_freeling-eng-slevel.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9a3e7f92b017e2274af2586b8aa25c86472704353758216abc3d057369625b3c
+size 1290

--- a/tests/test_corpora/freeling-fra-txt/config.yaml
+++ b/tests/test_corpora/freeling-fra-txt/config.yaml
@@ -46,7 +46,7 @@ export:
         - csv_export:csv
         - cwb:vrt
         - cwb:vrt_scrambled
-        - stats_export:freq_list_simple
+        - stats_export:sbx_freq_list_simple
         - xml_export:pretty
         - xml_export:preserved_format
     # Automatic annotations to be included in the export

--- a/tests/test_corpora/freeling-fra-txt/gold_export/frequency_list/stats_freeling-fra-txt.csv
+++ b/tests/test_corpora/freeling-fra-txt/gold_export/frequency_list/stats_freeling-fra-txt.csv
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ce5e8c83db4b11aeb4c3381b13e39953a4e112f4392d69fcd283a68ea674a109
-size 5980

--- a/tests/test_corpora/freeling-fra-txt/gold_export/frequency_list_sbx/stats_freeling-fra-txt.csv
+++ b/tests/test_corpora/freeling-fra-txt/gold_export/frequency_list_sbx/stats_freeling-fra-txt.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8a25bb68b3ef3ca9831611b1d03cf05044720bcc51d669c6fe5fd5d17c4e01e3
+size 5312

--- a/tests/test_corpora/mini-swe/config.yaml
+++ b/tests/test_corpora/mini-swe/config.yaml
@@ -46,7 +46,7 @@ export:
         - cwb:vrt
         - cwb:vrt_scrambled
         - korp:timespan_sql
-        - stats_export:freq_list_simple
+        - stats_export:sbx_freq_list_simple_swe
         - xml_export:pretty
         - xml_export:preserved_format
         - xml_export:scrambled

--- a/tests/test_corpora/mini-swe/gold_export/frequency_list/stats_mini-swe.csv
+++ b/tests/test_corpora/mini-swe/gold_export/frequency_list/stats_mini-swe.csv
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7c3816781b5312b0b4f14a7f2296012b7970815c611db14570b9567d614f2bc2
-size 3275

--- a/tests/test_corpora/mini-swe/gold_export/frequency_list_sbx/stats_mini-swe.csv
+++ b/tests/test_corpora/mini-swe/gold_export/frequency_list_sbx/stats_mini-swe.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eb94e774fd9f8bc648ba72af240a354bc5cca8ca29b05b739f7c6342beb8187c
+size 2826

--- a/tests/test_corpora/mini-swe/gold_sparv-workdir/dokument1/segment.token/stats_export.baseform_first
+++ b/tests/test_corpora/mini-swe/gold_sparv-workdir/dokument1/segment.token/stats_export.baseform_first
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:70a91eb21f90556125e4212d76a16e0848060c3cd9568da41612835db13269aa
+size 998

--- a/tests/test_corpora/mini-swe/gold_sparv-workdir/dokument2/segment.token/stats_export.baseform_first
+++ b/tests/test_corpora/mini-swe/gold_sparv-workdir/dokument2/segment.token/stats_export.baseform_first
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fdc8609dd77f8993678b75896cb0c5495b1bd292d08b4e297a3fcf47ea20fdb5
+size 88

--- a/tests/test_corpora/standard-swe/config.yaml
+++ b/tests/test_corpora/standard-swe/config.yaml
@@ -29,6 +29,7 @@ xml_import:
     # Elements and attributes from the source XML that we want to be available as input for other annotations
     elements:
         - text:date
+        - document:name
 
 #===============================================================================
 # Annotation Class Settings
@@ -78,6 +79,14 @@ export:
         - not <token>:wsd.sense
         - <token>:misc.affixed
         - <token>:custom.convert.upper
+
+stats_export:
+    annotations:
+        - <token:pos>
+        - <token>:custom.convert.upper
+    source_annotations:
+        - document:name
+
 
 #===============================================================================
 # Custom Annotations

--- a/tests/test_corpora/standard-swe/gold_export/frequency_list/stats_standard-swe.csv
+++ b/tests/test_corpora/standard-swe/gold_export/frequency_list/stats_standard-swe.csv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:28924e00c31eeb7902282cbbf3937270269d69e55f6eceab7fed9d584d9d1c4e
-size 15223
+oid sha256:e4ffec4e1f3151749d722e50a8c482b3a48530058d3f87266a5b7a80eb02a7df
+size 7898

--- a/tests/test_corpora/stanford-eng/config.yaml
+++ b/tests/test_corpora/stanford-eng/config.yaml
@@ -38,7 +38,7 @@ export:
         - csv_export:csv
         - cwb:vrt
         - cwb:vrt_scrambled
-        - stats_export:freq_list_simple
+        - stats_export:sbx_freq_list_simple
         - xml_export:pretty
         - xml_export:preserved_format
     # Automatic annotations to be included in the export

--- a/tests/test_corpora/stanford-eng/gold_export/frequency_list/stats_stanford-eng.csv
+++ b/tests/test_corpora/stanford-eng/gold_export/frequency_list/stats_stanford-eng.csv
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d50ca3a03d81bfde67dedd8eabc1977049e3218c2bcd383702900aec103b89c0
-size 5654

--- a/tests/test_corpora/stanford-eng/gold_export/frequency_list_sbx/stats_stanford-eng.csv
+++ b/tests/test_corpora/stanford-eng/gold_export/frequency_list_sbx/stats_stanford-eng.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f5e2fe8f6d57cfd1901f8bea98c80ffdf93e284c42b063b5105152d105b10f06
+size 4920

--- a/tests/test_corpora/swe-1800/config.yaml
+++ b/tests/test_corpora/swe-1800/config.yaml
@@ -29,7 +29,7 @@ export:
         - conll_export:conllu
         - cwb:info
         - cwb:vrt
-        - stats_export:freq_list_simple
+        - stats_export:sbx_freq_list_simple_swe
         - xml_export:pretty
         - xml_export:preserved_format
 

--- a/tests/test_corpora/swe-1800/gold_export/frequency_list/stats_swe-1800.csv
+++ b/tests/test_corpora/swe-1800/gold_export/frequency_list/stats_swe-1800.csv
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a241832a205daa2dfb7e7d26b3c702b50bc11e6d88c9188ad81f9f8246b20b22
-size 3448

--- a/tests/test_corpora/swe-1800/gold_export/frequency_list_sbx/stats_swe-1800.csv
+++ b/tests/test_corpora/swe-1800/gold_export/frequency_list_sbx/stats_swe-1800.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:68d625518ffa859fa5fa33296af1886eddaf369dadb24e68081c85fa4cd4e792
+size 2951

--- a/tests/test_corpora/swe-1800/gold_sparv-workdir/boaorm/segment.token/stats_export.baseform_first
+++ b/tests/test_corpora/swe-1800/gold_sparv-workdir/boaorm/segment.token/stats_export.baseform_first
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7167beb3c65e6b894f18e8b7e741218c4635a633950da85fc43a413f851554f8
+size 1300

--- a/tests/test_corpora/swe-fsv/config.yaml
+++ b/tests/test_corpora/swe-fsv/config.yaml
@@ -28,6 +28,6 @@ export:
         - csv_export:csv
         - cwb:info
         - cwb:vrt
-        - stats_export:freq_list_fsv
+        - stats_export:sbx_freq_list_fsv
         - xml_export:pretty
         - xml_export:preserved_format

--- a/tests/test_corpora/swe-fsv/gold_export/frequency_list/stats_swe-fsv.csv
+++ b/tests/test_corpora/swe-fsv/gold_export/frequency_list/stats_swe-fsv.csv
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:88d9e268fa38e5ed0d29585aed4dd241b474befaa6c0a14f59f4f312ee7a8a4d
-size 10920

--- a/tests/test_corpora/swe-fsv/gold_export/frequency_list_sbx/stats_swe-fsv.csv
+++ b/tests/test_corpora/swe-fsv/gold_export/frequency_list_sbx/stats_swe-fsv.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8b3437607d8967b50fb5e24028cd61257e36ed80b0f5b45b77568d5a8651bb3c
+size 10655

--- a/tests/test_corpora/treetagger-nld/config.yaml
+++ b/tests/test_corpora/treetagger-nld/config.yaml
@@ -38,7 +38,7 @@ export:
         - csv_export:csv
         - cwb:vrt
         - cwb:vrt_scrambled
-        - stats_export:freq_list_simple
+        - stats_export:sbx_freq_list_simple
         - xml_export:pretty
         - xml_export:preserved_format
     # Automatic annotations to be included in the export

--- a/tests/test_corpora/treetagger-nld/gold_export/frequency_list/stats_treetagger-nld.csv
+++ b/tests/test_corpora/treetagger-nld/gold_export/frequency_list/stats_treetagger-nld.csv
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:be0b44751298213f3e6ae5bef882ce91566ab48c77df808010728e3e868b74ee
-size 2112

--- a/tests/test_corpora/treetagger-nld/gold_export/frequency_list_sbx/stats_treetagger-nld.csv
+++ b/tests/test_corpora/treetagger-nld/gold_export/frequency_list_sbx/stats_treetagger-nld.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1d0095e10ad9d407308a9edfb70566eb22ae48730b171d39303881ae69f0abaf
+size 1855


### PR DESCRIPTION
Introduced a new stats export where the user can include any annotation (including structural annotations). The old stats exports have been prefixed with `sbx_` as they are more specific to our needs at Språkbanken Text.