### PR TITLE
Support py310

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,63 @@
+name: CI
+
+on: [push, pull_request]
+
+
+
+jobs:
+  checks:
+    name: ${{ matrix.task.name }} py-${{ matrix.python-version }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      max-parallel: 4
+      fail-fast: false
+      matrix:
+        # TODO: enable if decided to test 3.7
+        # python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10"]
+        os: [ubuntu-latest]
+        task:
+          - name: Run tests
+            run: make noexternal-tests
+
+    steps:
+      - name: Checkout code
+        uses: nschloe/action-cached-lfs-checkout@v1
+        # Use these to explicitly include/exclude files:
+        # with:
+        #   include: "*"
+        #   exclude: ""
+
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      # ----------------------------------------------
+      #       load cached venv if cache exists
+      # ----------------------------------------------
+      - name: Load cached venv
+        id: cached-poetry-dependencies
+        uses: actions/cache@v3.2.3
+        with:
+          path: venv
+          key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/pyproject.toml') }}-${{ hashFiles('**/setup.py') }}-${{ hashFiles('.github/workflows/ci.yml') }}
+
+      #----------------------------------------------
+      # install dependencies if cache does not exist
+      #----------------------------------------------
+      - name: Install dependencies
+        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
+        run: |
+          make setup-venv
+          make dev
+
+      - name: Setup Sparv
+        run: |
+          venv/bin/sparv setup -d $PWD
+          tree .
+
+      - name: ${{ matrix.task.name }}
+        run: ${{ matrix.task.run }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@
 
 ### Changed
 
+- Added support for Python 3.10.
+- Dropped support for Python 3.6.
 - `AnnotationAllSourceFiles` now have the same methods as `Annotation`.
 - The util function `install_mysql` can now install locally as well as to a remote server.
 - Pre-built SALDO models are now downloaded instead of being built on demand.
@@ -128,7 +130,7 @@
     - `korp.remote_cwb_registry` is now called `cwb.remote_registry_dir`
     - `korp.remote_host` has been split into `korp.remote_host` (host for SQL files) and `cwb.remote_host` (host for CWB
        files)
-    - install target `korp:install_corpus` has been renamed and split into `cwb:install_corpus` and 
+    - install target `korp:install_corpus` has been renamed and split into `cwb:install_corpus` and
       `cwb:install_corpus_scrambled`
 - Renamed the following stats exports:
     `stats_export:freq_list` is now called `stats_export:sbx_freq_list`

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,80 @@
+
+.default: help
+
+.PHONY: help
+help:
+	@echo "usage:"
+	@echo ""
+	@echo "setup-venv"
+	@echo "   create virtual environment"
+	@echo "dev | install-dev"
+	@echo "   setup development environment"
+	@echo ""
+	@echo "test | run-all-tests"
+	@echo "   run all tests"
+	@echo ""
+	@echo "run-doc-tests"
+	@echo "   run all tests"
+	@echo ""
+	@echo "run-all-tests-w-coverage"
+	@echo "   run all tests with coverage collection"
+	@echo ""
+	@echo "lint"
+	@echo "   lint the code"
+	@echo ""
+	@echo "type-check"
+	@echo "   check types"
+	@echo ""
+	@echo "fmt"
+	@echo "   run formatter(s)"
+	@echo ""
+	@echo "check-fmt"
+	@echo "   check formatting"
+	@echo ""
+
+PLATFORM := ${shell uname -o}
+PROJECT := sparv
+
+ifeq (${VIRTUAL_ENV},)
+  VENV_NAME = venv
+  INVENV = export VIRTUAL_ENV="${VENV_NAME}"; export PATH="${VENV_NAME}/bin:${PATH}"; unset PYTHON_HOME;
+else
+  VENV_NAME = ${VIRTUAL_ENV}
+  INVENV =
+endif
+
+${info Platform: ${PLATFORM}}
+
+setup-venv:
+	python3 -m venv ${VENV_NAME}
+	${VENV_NAME}/bin/pip install wheel
+
+dev: install-dev
+install-dev:
+	${VENV_NAME}/bin/pip install -e .[dev]
+
+setup-sparv:
+	${INVENV} sparv setup
+
+setup-sparv-from-env:
+	${INVENV} sparv setup --dir ${SPARV_DATADIR}
+
+.PHONY: test
+test: run-all-tests
+.PHONY: run-all-tests
+run-all-tests:
+	${INVENV} pytest
+
+.PHONY: noexternal-tests
+noexternal-tests:
+	${INVENV} pytest -m noexternal
+
+.PHONY: run-all-tests-w-coverage
+run-all-tests-w-coverage:
+	${INVENV} pytest -vv --cov=${PROJECT}  --cov-report=xml tests
+
+.PHONY: run-all-tests-w-coverage
+run-noexternal-tests-w-coverage:
+	${INVENV} pytest -vv --cov=${PROJECT}  --cov-report=xml -m noexternal
+
+

--- a/Makefile
+++ b/Makefile
@@ -13,11 +13,17 @@ help:
 	@echo "test | run-all-tests"
 	@echo "   run all tests"
 	@echo ""
-	@echo "run-doc-tests"
-	@echo "   run all tests"
+	@echo "noexternal-tests"
+	@echo "   run all tests marked with 'noexternal'"
+	@echo ""
+	@echo "unit-tests"
+	@echo "   run all tests marked with 'unit'"
 	@echo ""
 	@echo "run-all-tests-w-coverage"
 	@echo "   run all tests with coverage collection"
+	@echo ""
+	@echo "run-noexternal-tests-w-coverage"
+	@echo "   run all tests marked with 'noexternal' with coverage collection"
 	@echo ""
 	@echo "lint"
 	@echo "   lint the code"
@@ -68,6 +74,10 @@ run-all-tests:
 .PHONY: noexternal-tests
 noexternal-tests:
 	${INVENV} pytest -m noexternal
+
+.PHONY: unit-tests
+unit-tests:
+	${INVENV} pytest -m unit
 
 .PHONY: run-all-tests-w-coverage
 run-all-tests-w-coverage:

--- a/pytest.ini
+++ b/pytest.ini
@@ -10,3 +10,4 @@ markers =
     freeling: tests for FreeLing corpora
     stanford: tests for Stanford Parser corpora
     noexternal: tests that can be runned directly
+    unit: unit tests

--- a/pytest.ini
+++ b/pytest.ini
@@ -9,3 +9,4 @@ markers =
     treetagger: tests for Treetagger corpora
     freeling: tests for FreeLing corpora
     stanford: tests for Stanford Parser corpora
+    noexternal: tests that can be runned directly

--- a/setup.py
+++ b/setup.py
@@ -39,10 +39,10 @@ setuptools.setup(
     python_requires=">=3.6.2",
     install_requires=[
         "appdirs==1.4.4",
-        "iso-639==0.4.5",
         "docx2python==1.27.1",
         "nltk==3.6.7",
         "protobuf~=3.19.0", # Used by Stanza; see https://github.com/spraakbanken/sparv-pipeline/issues/161
+        "pycountry==22.3.5",
         "python-dateutil==2.8.2",
         "PyYAML==6.0",
         "questionary==1.10.0",

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setuptools.setup(
         "snakemake==6.3.0",
         "stanza==1.4.0",
         "torch>=1.9.1",  # Used by Stanza; see https://github.com/spraakbanken/sparv-pipeline/issues/82
-        "typing-inspect==0.7.1"
+        "typing-inspect==0.8.0"
     ],
     extras_require={
         "dev": [

--- a/setup.py
+++ b/setup.py
@@ -55,8 +55,8 @@ setuptools.setup(
     extras_require={
         "dev": [
             "pandocfilters==1.5.0",
-            "pytest==6.2.5",
-            "pytest-sugar==0.9.4"
+            "pytest",
+            "pytest-sugar>=0.9.6"
         ]
     },
     entry_points={

--- a/sparv/core/language_registry.py
+++ b/sparv/core/language_registry.py
@@ -1,0 +1,21 @@
+from typing import Optional
+import pycountry
+
+
+class LanguageRegistry(dict):
+    """Registry for installed languages."""
+
+    def add_language(self, lang: str) -> str:
+        if lang not in self:
+            langcode, _, suffix = lang.partition("-")
+            iso_lang = self.get_language_name_by_part3(langcode)
+            if iso_lang:
+                self[lang] = f"{iso_lang} ({suffix})" if suffix else iso_lang
+            else:
+                self[lang] = lang
+        return self[lang]
+
+    @staticmethod
+    def get_language_name_by_part3(part3: str) -> Optional[str]:
+        lang = pycountry.languages.get(alpha_3=part3)
+        return lang.name if lang else None

--- a/sparv/core/language_registry.py
+++ b/sparv/core/language_registry.py
@@ -19,3 +19,8 @@ class LanguageRegistry(dict):
     def get_language_name_by_part3(part3: str) -> Optional[str]:
         lang = pycountry.languages.get(alpha_3=part3)
         return lang.name if lang else None
+
+    @staticmethod
+    def get_language_part1_by_part3(part3: str) -> Optional[str]:
+        lang = pycountry.languages.get(alpha_3=part3)
+        return lang.alpha_2 if lang else None

--- a/sparv/core/registry.py
+++ b/sparv/core/registry.py
@@ -7,12 +7,12 @@ from collections import defaultdict
 from enum import Enum
 from typing import Callable, Dict, List, Optional, Tuple, Type, TypeVar
 
-import iso639
 import typing_inspect
 
 from sparv.core import config as sparv_config
 from sparv.core import paths
 from sparv.core.console import console
+from sparv.core.language_registry import LanguageRegistry
 from sparv.core.misc import SparvErrorMessage
 from sparv.api.classes import (BaseOutput, Config, Export, ExportAnnotations, ExportAnnotationsAllSourceFiles,
                                SourceAnnotations, SourceStructureParser, ModelOutput, OutputMarker, Wildcard)
@@ -64,7 +64,7 @@ all_module_classes = defaultdict(lambda: defaultdict(list))
 wizards = []
 
 # All supported languages
-languages = {}
+languages = LanguageRegistry()
 
 # All config keys containing lists of automatic annotations (i.e. ExportAnnotations)
 annotation_sources = {"export.annotations"}
@@ -297,14 +297,7 @@ def _add_to_registry(annotator):
     if annotator["language"]:
         # Add to set of supported languages...
         for lang in annotator["language"]:
-            if lang not in languages:
-                langcode, _, suffix = lang.partition("-")
-                if suffix:
-                    suffix = f" ({suffix})"
-                if langcode in iso639.languages.part3:
-                    languages[lang] = iso639.languages.get(part3=langcode).name + suffix
-                else:
-                    languages[lang] = lang
+            languages.add_language(lang)
         # ... but skip annotators for other languages than the one specified in the config
         if sparv_config.get("metadata.language") and not check_language(
                 sparv_config.get("metadata.language"), annotator["language"], sparv_config.get("metadata.variety")):

--- a/sparv/modules/stanza/models.py
+++ b/sparv/modules/stanza/models.py
@@ -3,9 +3,8 @@
 import json
 import logging
 
-import iso639
-
 from sparv.api import Language, Model, ModelOutput, modelbuilder, get_logger
+from sparv.core.language_registry import LanguageRegistry
 
 logger = get_logger(__name__)
 
@@ -70,8 +69,8 @@ def get_model(lang: Language = Language(),
               resources_file: ModelOutput = ModelOutput("stanza/[metadata.language]/resources.json")):
     """Download Stanza language models."""
     import stanza
-    lang_name = iso639.languages.get(part3=lang).name if lang in iso639.languages.part3 else lang
-    stanza_lang = iso639.languages.get(part3=lang).part1
+    lang_name = LanguageRegistry.get_language_name_by_part3(lang) or lang
+    stanza_lang = LanguageRegistry.get_language_part1_by_part3(lang)
     logger.info(f"Downloading Stanza language model for {lang_name}")
     stanza.download(lang=stanza_lang, model_dir=str(resources_file.path.parent), verbose=False,
                     logging_level=logging.WARNING)

--- a/sparv/modules/stanza/stanza.py
+++ b/sparv/modules/stanza/stanza.py
@@ -2,9 +2,8 @@
 
 from typing import Optional
 
-import iso639
-
 from sparv.api import Annotation, Config, Language, Model, Output, Text, annotator, get_logger, util
+from sparv.core.language_registry import LanguageRegistry
 from . import stanza_utils
 
 logger = get_logger(__name__)
@@ -51,7 +50,7 @@ def annotate(corpus_text: Text = Text(),
 
     # Define some values needed for Stanza Pipeline
     nlp_args = {
-        "lang": iso639.languages.get(part3=lang).part1,
+        "lang": LanguageRegistry.get_language_part1_by_part3(lang),
         "processors": "tokenize,mwt,pos,lemma,depparse,ner",  # Comma-separated list of processors to use
         "dir": str(resources_file.path.parent),
         "depparse_max_sentence_size": 200,  # Create new batch when encountering sentences larger than this

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -9,6 +9,7 @@ from . import utils
 
 
 @pytest.mark.swe
+# @pytest.mark.noexternal  TODO: this test fails in CI, enable when fixed
 def test_mini_swe(tmp_path):
     """Run corpus mini-swe and compare the annotations and exports to gold standard."""
     gold_corpus_dir = pathlib.Path("tests/test_corpora/mini-swe")
@@ -18,6 +19,7 @@ def test_mini_swe(tmp_path):
 
 
 @pytest.mark.swe
+@pytest.mark.noexternal
 def test_special_swe(tmp_path):
     """Run corpus special-swe and compare the annotations and exports to gold standard."""
     gold_corpus_dir = pathlib.Path("tests/test_corpora/special-swe")
@@ -27,6 +29,7 @@ def test_special_swe(tmp_path):
 
 
 @pytest.mark.swe
+@pytest.mark.noexternal
 def test_txt_swe(tmp_path):
     """Run corpus txt-swe and compare the annotations and exports to gold standard."""
     gold_corpus_dir = pathlib.Path("tests/test_corpora/txt-swe")
@@ -58,6 +61,7 @@ def test_swe_1800(tmp_path):
 
 @pytest.mark.swe
 @pytest.mark.swehist
+@pytest.mark.noexternal
 def test_swe_fsv(tmp_path):
     """Run corpus swe-fsv and compare the annotations and exports to gold standard."""
     gold_corpus_dir = pathlib.Path("tests/test_corpora/swe-fsv")

--- a/tests/unit/test_language_registry.py
+++ b/tests/unit/test_language_registry.py
@@ -1,0 +1,22 @@
+import pytest
+
+from sparv.core.language_registry import LanguageRegistry
+
+
+@pytest.fixture()
+def language_registry() -> LanguageRegistry:
+    return LanguageRegistry()
+
+
+class TestLanguageRegistry:
+    def check(self, tested: str, expected: str):
+        assert tested == expected
+
+    @pytest.mark.parametrize("lang, expected", [("swe", "Swedish"), ("xxx", "xxx")])
+    def test_add_language_succeeds(self, language_registry: LanguageRegistry, lang: str, expected: str):
+        res = language_registry.add_language(lang)
+        self.check(res, expected)
+        self.check(language_registry[lang], expected)
+
+
+

--- a/tests/unit/test_language_registry.py
+++ b/tests/unit/test_language_registry.py
@@ -1,3 +1,4 @@
+from typing import Optional
 import pytest
 
 from sparv.core.language_registry import LanguageRegistry
@@ -9,14 +10,21 @@ def language_registry() -> LanguageRegistry:
 
 
 class TestLanguageRegistry:
-    def check(self, tested: str, expected: str):
+    def check(self, tested: Optional[str], expected: str):
         assert tested == expected
 
     @pytest.mark.parametrize("lang, expected", [("swe", "Swedish"), ("xxx", "xxx")])
+    @pytest.mark.unit
+    @pytest.mark.noexternal
     def test_add_language_succeeds(self, language_registry: LanguageRegistry, lang: str, expected: str):
         res = language_registry.add_language(lang)
         self.check(res, expected)
         self.check(language_registry[lang], expected)
 
+    @pytest.mark.parametrize("lang, expected", [("swe", "sv"), ("xxx", None)])
+    @pytest.mark.unit
+    @pytest.mark.noexternal
+    def test_get_part1_by_part3(self, lang: str, expected: str):
+        self.check(LanguageRegistry.get_language_part1_by_part3(lang), expected)
 
 


### PR DESCRIPTION
I have replaced `iso639` with `pycountry` and factored out the code that uses that: sparv/core/language_registry.py

I have added Github Actions workflow for testing the code.
Doesn't test python 3.7 due to #172 
The tests passed last week: https://github.com/spraakbanken/sparv-pipeline/actions/runs/3959022657
But not now: https://github.com/spraakbanken/sparv-pipeline/actions/runs/3984861818
And I don't know why, do you have any idea?

